### PR TITLE
Ajout d'une commande !disable pour désactiver le chat continu.

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ async def enable(ctx):
     # Fonction pour lire les lignes du processus
     async def read_process():
         global stop_reading
-        while not stop_reading:
+        if stop_reading == False :
             try:
                 while True:
                     line = await asyncio.to_thread(process.stdout.readline)
@@ -56,10 +56,12 @@ async def enable(ctx):
                     if match:
                         username, message = match.groups()
                         await ctx.send(f"{username}: {message}")
+                        print(stop_reading)
             
             except Exception as e:
                 print(f"Erreur dans read_process: {e}")
-        
+        else :
+            return
     # Lancez la lecture des messages Minecraft dans un thread
     asyncio.create_task(read_process())
   
@@ -81,9 +83,16 @@ async def disable(ctx):
         # Arrêtez la lecture des messages Minecraft
         global stop_reading
         stop_reading = True
+        print(stop_reading)
         
-        # Attendre que la tâche se termine
-        await asyncio.sleep(0.1)  # Un peu de temps pour que la tâche se termine proprement
+        # Rafraîchissez manuellement la valeur de stop_reading
+        await asyncio.sleep(0.01)  # Un peu de temps pour que le changement soit pris en compte
+        
+        # Arrêtez la lecture des messages Minecraft
+        bot.stop_reading = True
+        
+        # Attendre que la tâse se termine
+        await asyncio.sleep(0.1)
         
         # Envoyez un message de confirmation
         await ctx.send("La commande a été désactivée. L'envoi des messages Minecraft vers Discord est maintenant désactivé et l'envoi de messages Discord vers Minecraft s'est arrêté.")

--- a/main.py
+++ b/main.py
@@ -59,16 +59,32 @@ async def enable(ctx):
         
     # Lancez la lecture des messages Minecraft dans un thread
     asyncio.create_task(read_process())
-
-    # Variable globale pour savoir si la commande est active
-    bot.rewrite_active = True
+  
+@bot.command()
+async def disable(ctx):
+    if not ctx.author.guild_permissions.administrator:
+        await ctx.send("Vous n'avez pas les permissions nécessaires pour exécuter cette commande.")
+        return
     
+    # Arrêtez l'envoi de messages Discord vers Minecraft
+    if hasattr(bot, 'minecraft_channel_id') and bot.minecraft_channel_id:
+        bot.minecraft_channel_id = None
+
+        # Fermez le processus qui lit les logs de Minecraft
+        if hasattr(bot, 'minecraft_log_process') and bot.minecraft_log_process:
+            print("Arrêt du processus de lecture des logs Minecraft...")
+            bot.minecraft_log_process.terminate()
+        
+        # Envoyez un message de confirmation
+        await ctx.send("La commande a été désactivée. L'envoi des messages Minecraft vers Discord est maintenant désactivé et l'envoi de messages Discord vers Minecraft s'est arrêté.")
+    
+    else:
+        await ctx.send("La commande n'était pas activée.")
 
 @bot.event
 async def on_message(message):
     if message.author.bot:
         return
-    
     if hasattr(bot, 'minecraft_channel_id') and bot.minecraft_channel_id:
         if message.channel.id == bot.minecraft_channel_id:
             username = str(message.author)

--- a/main.py
+++ b/main.py
@@ -33,6 +33,10 @@ async def enable(ctx):
     await ctx.send("Commande active. Envoi actif des messages discord vers Minecraft...")
     await ctx.send("Envoi actif des messages Minecraft vers Discord...")
     
+    global stop_reading
+    if stop_reading == True:
+        stop_reading = False
+        
     # Capture les messages Minecraft
     process = subprocess.Popen(
         ['sudo', 'tail', '-f', '/home/minecraft/logs/latest.log'],
@@ -44,14 +48,11 @@ async def enable(ctx):
     
     # Fonction pour lire les lignes du processus
     async def read_process():
-        global stop_reading
-        if stop_reading == False :
             try:
-                while True:
+                while stop_reading == False:
                     line = await asyncio.to_thread(process.stdout.readline)
                     if not line:
                         break
-                    
                     match = re.search(r'<([^>]+)> (.+)', line.strip())
                     if match:
                         username, message = match.groups()
@@ -60,8 +61,6 @@ async def enable(ctx):
             
             except Exception as e:
                 print(f"Erreur dans read_process: {e}")
-        else :
-            return
     # Lancez la lecture des messages Minecraft dans un thread
     asyncio.create_task(read_process())
   

--- a/main.py
+++ b/main.py
@@ -69,11 +69,15 @@ async def disable(ctx):
     # Arrêtez l'envoi de messages Discord vers Minecraft
     if hasattr(bot, 'minecraft_channel_id') and bot.minecraft_channel_id:
         bot.minecraft_channel_id = None
-
+        
         # Fermez le processus qui lit les logs de Minecraft
         if hasattr(bot, 'minecraft_log_process') and bot.minecraft_log_process:
             print("Arrêt du processus de lecture des logs Minecraft...")
             bot.minecraft_log_process.terminate()
+        
+        # Annulez la tâche asyncio si elle existe
+        if hasattr(bot, 'read_process_task'):
+            bot.read_process_task.cancel()
         
         # Envoyez un message de confirmation
         await ctx.send("La commande a été désactivée. L'envoi des messages Minecraft vers Discord est maintenant désactivé et l'envoi de messages Discord vers Minecraft s'est arrêté.")


### PR DESCRIPTION
Ajout : Variable stop_reading pour arrêter/reprendre le transfert de chat.
Commandes :
disable : Met stop_reading à True pour stopper le chat.
enable : Réinitialise stop_reading à False pour reprendre le chat.
Correction : Résout le problème de réactivation du chat après désactivation.